### PR TITLE
feat(train): add LinePlotter, LogParser, and visualization documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ setup-tensorboard:
 	@echo '=== Setup TensorBoard ==='
 	$(UV) pip install -e ".[tensorboard]"
 
+setup-plotting:
+	@echo '=== Setup TensorBoard ==='
+	$(UV) pip install -e ".[plotting]"
+
 check: typecheck format lint docstring-check
 
 format:

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -9,3 +9,4 @@
 | **Benchmarking** | How to run benchmarks and compare results | [Benchmarking](../user-guide/benchmarking.md) |
 | **Loggers** | Built-in loggers and how to implement custom loggers | [Loggers](../user-guide/loggers.md) |
 | **TensorBoard** | Using TensorBoard with HyperTorch | [TensorBoard](../user-guide/tensorboard.md) |
+| **Plotting** | How to visualize plots from HyperTorch's training data | [Plotting] (../user-guide/plotting.md) |

--- a/docs/user-guide/plotting.md
+++ b/docs/user-guide/plotting.md
@@ -18,14 +18,14 @@ By default, calling `plot()` plots every numerical metric tracked in the CSV:
 ```python
 from hypertorch.train import LinePlotter, LogParser
 
-#Initialize parser (defaults to "hypertorch_logs")
+# Initialize parser (defaults to "hypertorch_logs")
 parser = LogParser()
 
 # Locate the latest experiment directory and load metrics
 latest_dir = parser.find_latest_experiment_dir()
 df, csv_path = parser.load_latest_metrics()
 
-#Generate line plots for all available metrics
+# Generate line plots for all available metrics
 plotter = LinePlotter(latest_dir)
 saved_plots = plotter.plot(df, csv_path)
 ```
@@ -58,7 +58,7 @@ df, csv_path = parser.load_latest_metrics()
 
 plotter = LinePlotter(latest_dir)
 
-#Only generate plots for training and validation loss
+# Only generate plots for training and validation loss
 target_metrics = ["train/loss", "val/loss"]
 saved_plots = plotter.plot(df, csv_path, metrics=target_metrics)
 ```
@@ -66,7 +66,7 @@ saved_plots = plotter.plot(df, csv_path, metrics=target_metrics)
 Alternatively, you can filter the Pandas DataFrame directly before plotting:
 
 ```python
-#Keep metadata columns (epoch/step) and your desired metrics
+# Keep metadata columns (epoch/step) and your desired metrics
 selected_cols = [col for col in ["epoch", "step", "val/accuracy"] if col in df.columns]
 filtered_df = df[selected_cols]
 

--- a/docs/user-guide/plotting.md
+++ b/docs/user-guide/plotting.md
@@ -1,0 +1,87 @@
+# Plotting
+
+HyperTorch provides lightweight utilities to inspect, parse, and visualize training metrics logged across experiments. 
+The visualization pipeline centers around two primary components:
+
+* **`LogParser`**: Scans the experiment logging tree (`hypertorch_logs/`), locates experiment runs, and extracts tabular data into Pandas DataFrames.
+* **`LinePlotter`**: Generates publication-ready metric line charts from parsed logs, organizing them by model and metric tag.
+
+For a runnable example script, see: 
+- [`examples/plot/lineplot.py`](../../examples/plot/lineplot.py)
+
+---
+
+## Basic Plot Generation
+
+By default, calling `plot()` plots every numerical metric tracked in the CSV:
+
+```python
+from hypertorch.train import LinePlotter, LogParser
+
+#Initialize parser (defaults to "hypertorch_logs")
+parser = LogParser()
+
+# Locate the latest experiment directory and load metrics
+latest_dir = parser.find_latest_experiment_dir()
+df, csv_path = parser.load_latest_metrics()
+
+#Generate line plots for all available metrics
+plotter = LinePlotter(latest_dir)
+saved_plots = plotter.plot(df, csv_path)
+```
+
+Plots are saved to an isolated `plots/` subdirectory inside the experiment folder:
+
+```text
+hypertorch_logs/
+└── experiment_*/
+    ├── <model_name>/
+    └── plots/
+        ├── train_loss.png
+        ├── val_loss.png
+        └── val_accuracy.png
+```
+
+---
+
+### Selective Plotting (Filtering Metrics)
+
+If you only want to visualize specific curves—such as loss curves or evaluation metrics—pass 
+a list of metric column names via the `metrics` argument:
+
+```python
+from hypertorch.train import LinePlotter, LogParser
+
+parser = LogParser()
+latest_dir = parser.find_latest_experiment_dir()
+df, csv_path = parser.load_latest_metrics()
+
+plotter = LinePlotter(latest_dir)
+
+#Only generate plots for training and validation loss
+target_metrics = ["train/loss", "val/loss"]
+saved_plots = plotter.plot(df, csv_path, metrics=target_metrics)
+```
+
+Alternatively, you can filter the Pandas DataFrame directly before plotting:
+
+```python
+#Keep metadata columns (epoch/step) and your desired metrics
+selected_cols = [col for col in ["epoch", "step", "val/accuracy"] if col in df.columns]
+filtered_df = df[selected_cols]
+
+saved_plots = plotter.plot(filtered_df, csv_path)
+```
+
+### Loading Specific Runs with `load_csv`
+
+To inspect a specific historical run or individual model directory, 
+pass either a relative or absolute path to `load_csv`:
+
+```python
+# Relative paths resolve against base_logs_dir
+df, resolved_path = parser.load_csv("experiment_1/gcn/version_0/metrics.csv")
+
+# Absolute paths are accepted as-is
+df, resolved_path = parser.load_csv("C:/hypertorch_logs/experiment_0/metrics.csv")
+```

--- a/examples/plot/lineplot.py
+++ b/examples/plot/lineplot.py
@@ -1,0 +1,14 @@
+from hypertorch.train import LinePlotter, LogParser
+
+#Initialize parser with the experiment log root
+parser = LogParser("hypertorch_logs")
+
+#Automatically locate and load the newest experiment run
+df, csv_path = parser.load_latest_metrics()
+latest_dir = parser.find_latest_experiment_dir()
+
+#Generate line plots for all tracked metrics
+plotter = LinePlotter(latest_dir)
+saved_plots = plotter.plot(df, csv_path)
+
+print(f"Generated {len(saved_plots)} plots in {latest_dir / 'plots'}")

--- a/examples/plot/lineplot.py
+++ b/examples/plot/lineplot.py
@@ -1,13 +1,13 @@
 from hypertorch.train import LinePlotter, LogParser
 
-#Initialize parser with the experiment log root
+# Initialize parser with the experiment log root
 parser = LogParser("hypertorch_logs")
 
-#Automatically locate and load the newest experiment run
+# Automatically locate and load the newest experiment run
 df, csv_path = parser.load_latest_metrics()
 latest_dir = parser.find_latest_experiment_dir()
 
-#Generate line plots for all tracked metrics
+# Generate line plots for all tracked metrics
 plotter = LinePlotter(latest_dir)
 saved_plots = plotter.plot(df, csv_path)
 

--- a/hypertorch/tests/plot/logparser_test.py
+++ b/hypertorch/tests/plot/logparser_test.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import pandas as pd
+import pytest
+
+from hypertorch.train.logparser import LogParser
+
+
+def test_logparser_find_and_load(tmp_path: Path) -> None:
+    logs_dir = tmp_path / "hypertorch_logs"
+    exp_dir = logs_dir / "experiment_0" / "model" / "version_0"
+    exp_dir.mkdir(parents=True)
+
+    csv_path = exp_dir / "metrics.csv"
+    csv_path.write_text("epoch,step,train/loss\n0,1,0.5\n1,2,0.3\n")
+
+    parser = LogParser(logs_dir)
+    latest_exp = parser.find_latest_experiment_dir()
+    assert latest_exp == logs_dir / "experiment_0"
+
+    df, loaded_csv = parser.load_metrics()
+    assert loaded_csv == csv_path
+    assert isinstance(df, pd.DataFrame)
+    assert "train/loss" in df.columns
+
+
+def test_logparser_missing_dir_raises_error(tmp_path: Path) -> None:
+    parser = LogParser(tmp_path / "non_existent_dir")
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        parser.find_latest_experiment_dir()
+
+
+def test_logparser_empty_dir_raises_error(tmp_path: Path) -> None:
+    logs_dir = tmp_path / "hypertorch_logs"
+    (logs_dir / "experiment_0").mkdir(parents=True)
+
+    parser = LogParser(logs_dir)
+    with pytest.raises(FileNotFoundError, match="No CSV metric files found"):
+        parser.find_latest_metrics_csv()
+
+
+def test_logparser_no_subdirectories(tmp_path: Path) -> None:
+    logs_dir = tmp_path / "hypertorch_logs"
+    logs_dir.mkdir()  # Directory exists, but has no subdirectories
+    parser = LogParser(logs_dir)
+    with pytest.raises(FileNotFoundError, match="No experiment folders found"):
+        parser.find_latest_experiment_dir()

--- a/hypertorch/tests/plot/logparser_test.py
+++ b/hypertorch/tests/plot/logparser_test.py
@@ -17,7 +17,7 @@ def test_logparser_find_and_load(tmp_path: Path) -> None:
     latest_exp = parser.find_latest_experiment_dir()
     assert latest_exp == logs_dir / "experiment_0"
 
-    df, loaded_csv = parser.load_metrics()
+    df, loaded_csv = parser.load_latest_metrics()
     assert loaded_csv == csv_path
     assert isinstance(df, pd.DataFrame)
     assert "train/loss" in df.columns
@@ -40,7 +40,61 @@ def test_logparser_empty_dir_raises_error(tmp_path: Path) -> None:
 
 def test_logparser_no_subdirectories(tmp_path: Path) -> None:
     logs_dir = tmp_path / "hypertorch_logs"
-    logs_dir.mkdir()  # Directory exists, but has no subdirectories
+    logs_dir.mkdir()
     parser = LogParser(logs_dir)
     with pytest.raises(FileNotFoundError, match="No experiment folders found"):
         parser.find_latest_experiment_dir()
+
+
+def test_logparser_load_csv_relative_and_absolute(tmp_path: Path) -> None:
+    logs_dir = tmp_path / "hypertorch_logs"
+    exp_dir = logs_dir / "experiment_0"
+    exp_dir.mkdir(parents=True)
+
+    csv_path = exp_dir / "metrics.csv"
+    csv_path.write_text("epoch,loss\n0,0.4\n")
+
+    parser = LogParser(logs_dir)
+
+    # Relative path as string
+    df_rel_str, resolved_rel_str = parser.load_csv("experiment_0/metrics.csv")
+    assert resolved_rel_str == csv_path
+    assert not df_rel_str.empty
+
+    # Relative path as Path object
+    df_rel_path, resolved_rel_path = parser.load_csv(Path("experiment_0/metrics.csv"))
+    assert resolved_rel_path == csv_path
+    assert not df_rel_path.empty
+
+    # Absolute path
+    df_abs, resolved_abs = parser.load_csv(csv_path)
+    assert resolved_abs == csv_path
+    assert not df_abs.empty
+
+
+def test_logparser_load_csv_invalid_extension(tmp_path: Path) -> None:
+    logs_dir = tmp_path / "hypertorch_logs"
+    logs_dir.mkdir(parents=True)
+    txt_file = logs_dir / "metrics.txt"
+    txt_file.write_text("dummy")
+
+    parser = LogParser(logs_dir)
+    with pytest.raises(ValueError, match="is not a CSV file"):
+        parser.load_csv("metrics.txt")
+
+
+def test_logparser_load_csv_missing_file_or_directory(tmp_path: Path) -> None:
+    logs_dir = tmp_path / "hypertorch_logs"
+    logs_dir.mkdir(parents=True)
+
+    parser = LogParser(logs_dir)
+
+    # File does not exist
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        parser.load_csv("non_existent.csv")
+
+    # Path exists but is a directory ending with .csv
+    dir_named_csv = logs_dir / "folder.csv"
+    dir_named_csv.mkdir()
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        parser.load_csv("folder.csv")

--- a/hypertorch/tests/plot/plotter_test.py
+++ b/hypertorch/tests/plot/plotter_test.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+import matplotlib.axes._axes as maxes
+import pandas as pd
+import pytest
+from hypertorch.train.plotter import LinePlotter
+
+
+def test_line_plotter_initialization(tmp_path: Path) -> None:
+    exp_dir = tmp_path / "experiment_48"
+    exp_dir.mkdir()
+    plotter = LinePlotter(exp_dir)
+    assert plotter.num_exp == "48"
+    assert (exp_dir / "plots").exists()
+
+
+def test_line_plotter_generates_png(tmp_path: Path) -> None:
+    exp_dir = tmp_path / "experiment_0"
+    exp_dir.mkdir()
+    plotter = LinePlotter(exp_dir)
+
+    df = pd.DataFrame(
+        {
+            "epoch": [0, 1, 2],
+            "train/loss": [0.8, 0.5, 0.3],
+            "test/accuracy": [0.85, None, None],  # split == "test" -> True for blue color
+            "baseline/loss": [0.99, None, None],  # split == "test" -> False for gray color
+            "unslashed_metric": [1.0, 2.0, 3.0],  # no slash -> False for Split lambda ternary
+        }
+    )
+
+    created_plots = plotter.plot(df, exp_dir / "metrics.csv")
+    assert len(created_plots) > 0
+
+
+def test_line_plotter_x_col_and_tracking_collision(tmp_path: Path) -> None:
+    """Hits deeply nested x_col fallbacks and 'clean_var in tracking_cols' False branch."""
+    exp_dir = tmp_path / "experiment_0"
+    exp_dir.mkdir()
+    plotter = LinePlotter(exp_dir)
+
+    df_step = pd.DataFrame({"step": [1, 2], "train/loss": [0.5, 0.4]})
+    assert len(plotter.plot(df_step, exp_dir / "metrics.csv")) == 1
+
+    df_custom = pd.DataFrame({"custom_idx": [1, 2], "train/epoch": [10, 20]})
+    assert len(plotter.plot(df_custom, exp_dir / "metrics.csv")) == 0
+
+
+def test_line_plotter_branches(tmp_path: Path) -> None:
+    exp_dir = tmp_path / "experiment_0"
+    exp_dir.mkdir()
+    plotter = LinePlotter(exp_dir)
+
+    df = pd.DataFrame(
+        {
+            "epoch": [0, 1],
+            "loss": [0.5, 0.3],  # c == var_name (True)
+            "train/loss": [
+                0.6,
+                0.4,
+            ],  # c == var_name (False), "/" in c (True), split == var_name (True)
+            "accuracy": [0.7, 0.9],  # c == var_name (False), "/" in c (False)
+            "test/accuracy": [
+                0.8,
+                0.8,
+            ],  # c == var_name (False), "/" in c (True), split == var_name (False)
+        }
+    )
+
+    created_plots = plotter.plot(df, exp_dir / "metrics.csv", metrics=["loss"])
+    assert len(created_plots) == 1
+
+
+def test_line_plotter_empty_melted(tmp_path: Path) -> None:
+    exp_dir = tmp_path / "experiment_0"
+    exp_dir.mkdir()
+    plotter = LinePlotter(exp_dir)
+    df = pd.DataFrame({"epoch": [0, 1], "train/loss": [None, None]})
+    plots = plotter.plot(df, exp_dir / "metrics.csv")
+    assert len(plots) == 0
+
+
+def test_line_plotter_no_legend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    exp_dir = tmp_path / "experiment_0"
+    exp_dir.mkdir()
+    plotter = LinePlotter(exp_dir)
+    df = pd.DataFrame({"epoch": [0, 1], "train/loss": [0.5, 0.3]})
+    monkeypatch.setattr(maxes.Axes, "get_legend_handles_labels", lambda self: ([], []))
+    plots = plotter.plot(df, exp_dir / "metrics.csv")
+    assert len(plots) == 1

--- a/hypertorch/train/__init__.py
+++ b/hypertorch/train/__init__.py
@@ -8,13 +8,21 @@ from .markdown_logger import MarkdownTableLogger
 
 from .trainer import MultiModelTrainer
 
+from .logparser import LogParser
+
+from .plotter import LinePlotter, Plotter
+
+
 logging.getLogger("lightning.pytorch").setLevel(logging.ERROR)
 
 __all__ = [
     "ExperimentSharedLogger",
     "LaTexTableConfig",
     "LaTexTableLogger",
+    "LinePlotter",
+    "LogParser",
     "MarkdownTableLogger",
     "MultiModelTrainer",
+    "Plotter",
     "colorize_metric_value",
 ]

--- a/hypertorch/train/logparser.py
+++ b/hypertorch/train/logparser.py
@@ -81,7 +81,7 @@ class LogParser:
             FileNotFoundError: If the path does not exist or is not a file.
         """
         target_path = Path(path)
-        if not target_path.is_absolute():
+        if not target_path.is_absolute() and not target_path.is_relative_to(self.base_logs_dir):
             target_path = self.base_logs_dir / target_path
 
         if target_path.suffix.lower() != ".csv":

--- a/hypertorch/train/logparser.py
+++ b/hypertorch/train/logparser.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import pandas as pd
+
+
+class LogParser:
+    """
+    Finds and parses the metrics CSV from an experiment folder.
+
+    Currently, it only looks at the latest metrics CSV,
+    to be expanded with the ability to parse older experiments.
+
+    Args:
+        base_logs_dir: Root directory containing experiment run folders.
+
+    Note: defaults to 'hypertorch_logs'.
+    """
+
+    def __init__(self, base_logs_dir: str | Path = "hypertorch_logs") -> None:
+        self.base_logs_dir = Path(base_logs_dir)
+
+    def find_latest_experiment_dir(self) -> Path:
+        """
+        Finds the most recently modified experiment folder inside hypertorch_logs.
+        """
+        if not self.base_logs_dir.exists():
+            raise FileNotFoundError(f"Logs root directory '{self.base_logs_dir}' does not exist.")
+
+        # Filter for subdirectories only (e.g. experiment_0, experiment_1)
+        experiment_dirs = [p for p in self.base_logs_dir.iterdir() if p.is_dir()]
+        if not experiment_dirs:
+            raise FileNotFoundError(f"No experiment folders found inside '{self.base_logs_dir}'.")
+
+        # Sort folders by newest first
+        experiment_dirs.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        return experiment_dirs[0]
+
+    def find_latest_metrics_csv(self) -> Path:
+        """
+        Finds the most recently modified CSV inside the latest experiment folder.
+        """
+        latest_exp_dir = self.find_latest_experiment_dir()
+
+        # Recursively scan inside that latest experiment folder
+        csv_files = list(latest_exp_dir.rglob("*.csv"))
+        if not csv_files:
+            raise FileNotFoundError(
+                f"No CSV metric files found inside latest experiment folder: '{latest_exp_dir}'"
+            )
+
+        # Sort CSV files by newest first
+        csv_files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        return csv_files[0]
+
+    def load_metrics(self) -> tuple[pd.DataFrame, Path]:
+        """
+        Step 3: Loads the latest CSV into a Pandas DataFrame.
+
+        Returns:
+            A tuple of (DataFrame, CSV_File_Path).
+        """
+        target_csv = self.find_latest_metrics_csv()
+        df = pd.read_csv(target_csv)
+        return df, target_csv

--- a/hypertorch/train/logparser.py
+++ b/hypertorch/train/logparser.py
@@ -3,8 +3,7 @@ import pandas as pd
 
 
 class LogParser:
-    """
-    Finds and parses the metrics CSV from an experiment folder.
+    """Finds and parses the metrics CSV from an experiment folder.
 
     Currently, it only looks at the latest metrics CSV,
     to be expanded with the ability to parse older experiments.
@@ -19,45 +18,77 @@ class LogParser:
         self.base_logs_dir = Path(base_logs_dir)
 
     def find_latest_experiment_dir(self) -> Path:
-        """
-        Finds the most recently modified experiment folder inside hypertorch_logs.
+        """Finds the most recently modified experiment folder inside hypertorch_logs.
+
+        Raises:
+            FileNotFoundError: If there are no subdirectories or if
+                base_logs_dir does not exist.
         """
         if not self.base_logs_dir.exists():
             raise FileNotFoundError(f"Logs root directory '{self.base_logs_dir}' does not exist.")
 
-        # Filter for subdirectories only (e.g. experiment_0, experiment_1)
         experiment_dirs = [p for p in self.base_logs_dir.iterdir() if p.is_dir()]
         if not experiment_dirs:
             raise FileNotFoundError(f"No experiment folders found inside '{self.base_logs_dir}'.")
 
-        # Sort folders by newest first
         experiment_dirs.sort(key=lambda p: p.stat().st_mtime, reverse=True)
         return experiment_dirs[0]
 
     def find_latest_metrics_csv(self) -> Path:
-        """
-        Finds the most recently modified CSV inside the latest experiment folder.
+        """Finds the most recently modified CSV inside the latest experiment folder.
+
+        Raises:
+            FileNotFoundError: If there is no CSV metrics file in the latest folder.
         """
         latest_exp_dir = self.find_latest_experiment_dir()
 
-        # Recursively scan inside that latest experiment folder
         csv_files = list(latest_exp_dir.rglob("*.csv"))
         if not csv_files:
             raise FileNotFoundError(
                 f"No CSV metric files found inside latest experiment folder: '{latest_exp_dir}'"
             )
 
-        # Sort CSV files by newest first
         csv_files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
         return csv_files[0]
 
-    def load_metrics(self) -> tuple[pd.DataFrame, Path]:
-        """
-        Step 3: Loads the latest CSV into a Pandas DataFrame.
+    def load_latest_metrics(self) -> tuple[pd.DataFrame, Path]:
+        """Loads the latest CSV into a Pandas DataFrame.
 
         Returns:
             A tuple of (DataFrame, CSV_File_Path).
+
+        Raises:
+            FileNotFoundError: If there are no subdirectories, if base_logs_dir
+                does not exist, or if no CSV is found.
         """
         target_csv = self.find_latest_metrics_csv()
-        df = pd.read_csv(target_csv)
-        return df, target_csv
+        return self.load_csv(target_csv)
+
+    def load_csv(self, path: str | Path) -> tuple[pd.DataFrame, Path]:
+        """Loads a CSV into a Pandas DataFrame from the given path.
+
+        If a relative path is provided, it is resolved relative to
+        ``base_logs_dir``. Absolute paths are used as-is.
+
+        Args:
+            path: Relative or absolute path to the target CSV file.
+
+        Returns:
+            A tuple of (DataFrame, CSV_File_Path).
+
+        Raises:
+            ValueError: If the file is not a CSV.
+            FileNotFoundError: If the path does not exist or is not a file.
+        """
+        target_path = Path(path)
+        if not target_path.is_absolute():
+            target_path = self.base_logs_dir / target_path
+
+        if target_path.suffix.lower() != ".csv":
+            raise ValueError(f"File '{target_path}' is not a CSV file.")
+
+        if not target_path.is_file():
+            raise FileNotFoundError(f"CSV file '{target_path}' does not exist.")
+
+        df = pd.read_csv(target_path)
+        return df, target_path

--- a/hypertorch/train/plotter.py
+++ b/hypertorch/train/plotter.py
@@ -1,0 +1,162 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+import re
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+
+
+class Plotter(ABC):
+    """
+    Abstract Base Class (ABC) for all experiment plotters in HyperTorch.
+
+    Establishes a common structure, to be inherited by all the future classes
+    that specilize in a type of plot (Line, Scatter, etc etc)
+
+    Args:
+        experiment_dir: Path to the experiment directory (e.g., 'hypertorch_logs/experiment_0').
+
+    Note: generates the "plot" folder inside the experiment folder, where the plot will be placed.
+    """
+
+    def __init__(self, experiment_dir: str | Path) -> None:
+        self.experiment_dir = Path(experiment_dir)
+        self.plots_dir = self.experiment_dir / "plots"
+        self.plots_dir.mkdir(parents=True, exist_ok=True)
+
+    @abstractmethod
+    def plot(self, df: pd.DataFrame, csv_path: Path) -> list[Path]:
+        """
+        Abstract method that must be implemented by subclasses.
+
+        Args:
+            df: Metric DataFrame parsed from the CSV.
+            csv_path: Path to the source CSV file.
+
+        Returns:
+            A list of Paths pointing to created image files.
+        """
+
+
+class LinePlotter(Plotter):
+    """Generates Seaborn line plots for training and evaluation metrics."""
+
+    def __init__(self, experiment_dir: str | Path) -> None:
+        super().__init__(experiment_dir)
+        match = re.search(r"experiment_(\d+)", self.experiment_dir.name)
+        self.num_exp = match.group(1) if match else "0"
+
+    def plot(
+        self,
+        df: pd.DataFrame,
+        csv_path: Path,
+        metrics: list[str] | None = None,
+    ) -> list[Path]:
+        """
+        Renders and saves line plots for metrics across epochs/steps.
+
+        Args:
+            df: Metric DataFrame returned by LogParser.
+            csv_path: Source CSV path returned by LogParser.
+            metrics: Optional list of specific base variables to plot (e.g. ['loss']).
+                     If None, plots all available variables.
+
+        Returns:
+            List of generated plot image file paths.
+
+        Output:
+            LinePlot_{variable}_{num_exp}.png
+        """
+        x_col = (
+            "epoch"
+            if "epoch" in df.columns
+            else ("step" if "step" in df.columns else df.columns[0])
+        )
+
+        tracking_cols = {"epoch", "step"}
+        metric_cols = [c for c in df.columns if c not in tracking_cols]
+
+        variables = set()
+        for col in metric_cols:
+            clean_var = col.split("/", 1)[1] if "/" in col else col
+            if clean_var not in tracking_cols:
+                variables.add(clean_var)
+
+        if metrics:
+            variables = {v for v in variables if v in metrics}
+
+        sns.set_theme(style="darkgrid")
+        saved_plots: list[Path] = []
+
+        for var_name in sorted(variables):
+            matching_cols = [
+                c
+                for c in metric_cols
+                if c == var_name or ("/" in c and c.split("/", 1)[1] == var_name)
+            ]
+
+            melted = df.melt(
+                id_vars=[x_col],
+                value_vars=matching_cols,
+                var_name="Split",
+                value_name="value",
+            ).dropna()
+
+            if melted.empty:
+                continue
+
+            melted["Split"] = melted["Split"].apply(
+                lambda s: str(s).split("/", 1)[0] if "/" in str(s) else str(s)
+            )
+
+            fig, ax = plt.subplots(figsize=(8, 5))
+
+            split_counts = melted["Split"].value_counts()
+            single_point_splits = split_counts[split_counts == 1].index.tolist()
+
+            continuous_melted = melted[~melted["Split"].isin(single_point_splits)]
+            single_melted = melted[melted["Split"].isin(single_point_splits)]
+
+            for split in single_point_splits:
+                val = single_melted[single_melted["Split"] == split]["value"].values[0]
+                ax.axhline(
+                    y=val,
+                    color="#4C72B0" if split == "test" else "gray",
+                    linestyle="--",
+                    linewidth=1.5,
+                    alpha=0.7,
+                    zorder=1,
+                    label=f"{split} ({val:.4f})",
+                )
+
+            if not continuous_melted.empty:
+                sns.lineplot(
+                    data=continuous_melted,
+                    x=x_col,
+                    y="value",
+                    hue="Split",
+                    marker="o",
+                    ax=ax,
+                    zorder=3,
+                )
+
+            handles, labels = ax.get_legend_handles_labels()
+            if handles:
+                ax.legend(handles=handles, labels=labels, title="Split", loc="best")
+
+            formatted_title = var_name.replace("_", " ").capitalize()
+            ax.set_title(f"Experiment {self.num_exp} — {formatted_title}")
+            ax.set_xlabel(x_col.capitalize())
+            ax.set_ylabel(formatted_title)
+
+            clean_filename_var = var_name.replace("/", "_")
+            output_filename = f"LinePlot_{clean_filename_var}_{self.num_exp}.png"
+            output_path = self.plots_dir / output_filename
+
+            plt.tight_layout()
+            plt.savefig(output_path, dpi=300)
+            plt.close(fig)
+
+            saved_plots.append(output_path)
+
+        return saved_plots

--- a/hypertorch/train/plotter.py
+++ b/hypertorch/train/plotter.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 import re
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/hypertorch/train/plotter.py
+++ b/hypertorch/train/plotter.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
 import re
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
   "fastjsonschema>=2.21.2,<3.0.0",
   "huggingface-hub>=1.16.4,<2.0.0",
   "lightning>=2.6.1,<3.0.0",
+  "matplotlib>=3.8.0,<4.0.0",
+  "seaborn>=0.13.2,<1.0.0",
   "numpy>=2.2.6,<3.0.0 ; python_full_version < '3.11'",
   "numpy>=2.4.4,<3.0.0 ; python_full_version >= '3.11'",
   "pyg-lib>=0.6.0,<1.0.0 ; (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'darwin' and platform_machine == 'arm64')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,6 @@ dependencies = [
   "fastjsonschema>=2.21.2,<3.0.0",
   "huggingface-hub>=1.16.4,<2.0.0",
   "lightning>=2.6.1,<3.0.0",
-  "matplotlib>=3.8.0,<4.0.0",
-  "seaborn>=0.13.2,<1.0.0",
   "numpy>=2.2.6,<3.0.0 ; python_full_version < '3.11'",
   "numpy>=2.4.4,<3.0.0 ; python_full_version >= '3.11'",
   "pyg-lib>=0.6.0,<1.0.0 ; (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'darwin' and platform_machine == 'arm64')",
@@ -28,6 +26,10 @@ dependencies = [
 
 [project.optional-dependencies]
 tensorboard = ["tensorboard>=2.20.0,<3.0.0"]
+plotting = [
+  "matplotlib>=3.8.0,<4.0.0",
+  "seaborn>=0.13.2,<1.0.0",
+  ]
 
 [tool.uv]
 add-bounds = "major"
@@ -70,6 +72,8 @@ test = [
   "pytest-cov>=7.1.0,<8.0.0",
   "pytest-rerunfailures>=16.3,<17.0.0",
   "pytest-xdist>=3.0.0,<4.0.0",
+  "matplotlib>=3.8.0,<4.0.0",
+  "seaborn>=0.13.2,<1.0.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/zensical.toml
+++ b/zensical.toml
@@ -31,6 +31,7 @@ nav = [
     { "Benchmarking" = "user-guide/benchmarking.md" },
     { "Loggers" = "user-guide/loggers.md" },
     { "TensorBoard" = "user-guide/tensorboard.md" },
+    { "Plotting" = "user-guide/plotting.md"},
   ] },
   { "Development" = [
     { "Overview" = "development/development.md" },


### PR DESCRIPTION
### All submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same changes?
- [x] Have you made sure you have rebased your branch to the latest commit on the target branch?

### Description

This PR introduces parsing and visualization utilities to plot (line plot for now) experiment metrics logged across training runs:
- `LogParser` (`hypertorch/train/logparser.py`) automatically finds the latest metrics CSV file or loads one from a given path and converts them into the necessary seaborn tuple
- `LinePlotter` (`hypertorch/train/plotter.py`) generates line plots for all recorded metrics from a given tuple.

An example has been provided `examples/plot/lineplot.py` showcasing automated experiment detection and metric plotting.
Docs have been updated, with a section added for the new features.

### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you linted your code locally before submission? (use `make format`)
- [x] Have you type-checked your code locally before submission? (use `make typecheck`)
